### PR TITLE
Include redirect option (-r)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "koji-retriever"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koji-retriever"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ after a package build process.
 - 0.3.0:  Code refactoring
 - 0.4.0:  Fix cargo clippy error
 - 0.5.0:  Filter mode (-f). Allows providing a filter to only download packages whose URLs match the filter
+- 0.6.0:  Add redirect mode (-r). Perform link following on redirects
 
 ## Compilation
 
@@ -65,6 +66,7 @@ OPTIONS:
     -u, --url <URL>
     -f, --filter <FILTER>
     -d, --directory <DIRECTORY>
+    -r, --redirect
     -t, --test
     -h, --help                   Print help
     -V, --version                Print version

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ struct Args {
     directory: Option<String>,
     #[clap(short, long, value_parser)]
     test: bool,
+    #[clap(short, long, value_parser, default_value_t = false)]
+    redirect: bool,
 }
 
 fn parse(body: String) -> u32 {
@@ -49,6 +51,7 @@ fn parse(body: String) -> u32 {
             Args::parse().directory,
             Args::parse().test,
             Args::parse().filter,
+            Args::parse().redirect,
         ),
     ) {
         Ok(d) => d,

--- a/src/verbose.rs
+++ b/src/verbose.rs
@@ -37,7 +37,7 @@ pub fn is_verbose(v: bool) {
 
 pub fn dump_verbose(s: &String) {
     if VERBOSE.lock().unwrap().verbose {
-        println!("{}", s);
+        println!("{s}");
     }
 }
 

--- a/tests/koji-retriever-test.rs
+++ b/tests/koji-retriever-test.rs
@@ -135,7 +135,8 @@ fn url_existing_files_exist_test() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-u")
         .arg("https://koji.fedoraproject.org/koji/buildinfo?buildID=2249970")
         .arg("-d")
-        .arg("/tmp");
+        .arg("/tmp")
+        .arg("-r");
     cmd.assert().success().stdout(predicate::str::contains(
         "/tmp/pykickstart-3.48-3.fc39.src.rpm",
     ));

--- a/tests/links-tests.rs
+++ b/tests/links-tests.rs
@@ -61,6 +61,7 @@ fn links_downloadable_link_test() {
             std::option::Option::Some::<String>(DST_DIR.to_string()),
             false,
             std::option::Option::None::<String>,
+            true,
         ),
     ) {
         Ok(d) => assert_eq!(d, 1),
@@ -77,6 +78,7 @@ fn links_downloadable_link_test_filter() {
             std::option::Option::Some::<String>(DST_DIR.to_string()),
             false,
             std::option::Option::Some::<String>(FILTER2.to_string()),
+            true,
         ),
     ) {
         Ok(d) => assert_eq!(d, 1),
@@ -88,6 +90,7 @@ fn links_downloadable_link_test_filter() {
             std::option::Option::Some::<String>(DST_DIR.to_string()),
             false,
             std::option::Option::Some::<String>(UNEXISTING_FILTER.to_string()),
+            true,
         ),
     ) {
         Ok(d) => assert_eq!(d, 0),
@@ -104,6 +107,7 @@ fn links_not_dowloadable_link_test() {
             std::option::Option::Some::<String>(DST_DIR.to_string()),
             false,
             std::option::Option::None::<String>,
+            true,
         ),
     ) {
         Ok(d) => assert_eq!(d, 0),


### PR DESCRIPTION
Resolves: #296

## Summary by Sourcery

Add support for following redirects during file downloads

New Features:
- Add a new redirect option (-r) to follow HTTP redirects during file downloads

Enhancements:
- Update download_file function to support optional redirect following
- Modify DownloadData struct to include redirect flag