### PR TITLE
Align Cargo.toml/Cargo.lock (clap:4.5.36->4.5.38)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 assert_cmd = { version = "2.0.17" }
-clap = { version = "4.5.36", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 curl = { version = "0.4.47" }
 lazy_static = { version = "1.5.0" }
 predicates = { version = "3.1.3" }


### PR DESCRIPTION
Resolves: #354

## Summary by Sourcery

Chores:
- Update clap dependency to 4.5.38 in Cargo.toml and sync Cargo.lock