### PR TITLE
Add brewweb domain support for RPM link extraction

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,3 +1,7 @@
+ai
+AI
+claude
+CLAUDE
 CLI
 CLIPPY
 clippy
@@ -7,3 +11,7 @@ koji
 koji-retriever
 llvm
 Markdown
+markdown
+md
+Mutex
+mutex

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`koji-retriever` is a Rust CLI tool that downloads RPM packages from Koji build URLs (Fedora and Red Hat's build system). It parses HTML from Koji build pages, extracts package download links, and downloads the RPM files.
+
+## Build and Test Commands
+
+```bash
+# Build
+cargo build                    # Debug build
+cargo build --release          # Release build
+
+# Run tests
+cargo test                     # Run all tests
+cargo test --release          # Run tests in release mode
+
+# Run specific test
+cargo test url_existing_test
+
+# Format code
+cargo fmt
+
+# Linting
+cargo clippy
+
+# Security audit
+cargo audit
+```
+
+## Coverage Testing
+
+```bash
+# Setup (one-time)
+cargo install grcov
+rustup component add llvm-tools-preview
+
+# Generate coverage
+export RUSTFLAGS="-Cinstrument-coverage"
+export LLVM_PROFILE_FILE="koji-retriever-%p-%m.profraw"
+cargo test
+grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
+```
+
+## Architecture
+
+### Core Flow
+1. **main.rs**: Entry point. Uses `curl` to fetch the Koji build page HTML
+2. **links.rs**: Core logic for parsing and downloading
+   - `get_link_lines()`: Filters HTML lines containing RPM links
+   - `get_links()`: Extracts actual URLs from filtered HTML lines
+   - `download_links()`: Downloads each RPM file (with optional filtering)
+3. **verbose.rs**: Global verbose flag using `lazy_static` Mutex
+
+### Link Extraction
+The tool searches for HTML lines containing:
+- `<a href` tags
+- `.rpm` extension
+- Known Koji domains: `fedoraproject.org`, `download.devel.redhat.com`, `download.eng.bos.redhat.com`, `kojihub.stream.rdu2.redhat.com`, `dc.redhat.com` (brewweb)
+
+### Key Design Patterns
+- Uses `clap` derive macros for CLI argument parsing
+- Global state for verbose flag via `lazy_static` Mutex
+- Stream-based download using `curl` write callbacks
+- Test mode (-t) allows validation without actual downloads
+- Filter mode (-f) restricts downloads to URLs matching a pattern
+- Redirect mode (-r) follows HTTP redirects during download
+
+### CLI Arguments
+- `-u, --url`: Koji build URL (required)
+- `-f, --filter`: Filter to match URLs
+- `-d, --directory`: Download directory (defaults to current)
+- `-r, --redirect`: Follow HTTP redirects
+- `-t, --test`: Test mode (no actual downloads)
+- `-v, --verbose`: Enable verbose output
+
+## Testing
+
+Tests are located in `tests/` directory:
+- `koji-retriever-test.rs`: Main CLI integration tests using `assert_cmd`
+- `links-tests.rs`: Link parsing tests
+- `verbose-test.rs`: Verbose flag tests
+
+Tests use real Koji URLs and download to `/tmp`, so they require network access. The test suite includes commands like `ls` and `rm` to verify actual file downloads.
+
+## Dependencies
+
+Key dependencies:
+- `clap`: CLI argument parsing with derive macros
+- `curl`: HTTP downloads with streaming support
+- `lazy_static`: Global state management
+- `assert_cmd`, `predicates`, `cargo-bin`: Test utilities

--- a/src/links.rs
+++ b/src/links.rs
@@ -29,6 +29,7 @@ use super::verbose;
 const DOWNLOAD_DEVEL_REDHAT: &str = "download.devel.redhat.com";
 const DOWNLOAD_REDHAT: &str = "download.eng.bos.redhat.com";
 const DOWNLOAD_KOJIHUB: &str = "kojihub.stream.rdu2.redhat.com";
+const DOWNLOAD_BREWWEB: &str = "dc.redhat.com";
 const FEDORA_PROJECT: &str = "fedoraproject.org";
 const LINK_HTML: &str = "<a href";
 const LINK_HTML_EQUAL: &str = "<a href=";
@@ -73,7 +74,8 @@ pub fn get_link_lines(body: String) -> Vec<String> {
             && (s.contains(FEDORA_PROJECT)
                 || s.contains(DOWNLOAD_DEVEL_REDHAT)
                 || s.contains(DOWNLOAD_REDHAT)
-                || s.contains(DOWNLOAD_KOJIHUB))
+                || s.contains(DOWNLOAD_KOJIHUB)
+                || s.contains(DOWNLOAD_BREWWEB))
         {
             verbose::dump_verbose(&("get_link_lines: LINK LINE:".to_owned() + s));
             lines.push(s.to_string());

--- a/tests/links-tests.rs
+++ b/tests/links-tests.rs
@@ -45,6 +45,13 @@ const FILTER2: &str = "/3.62/";
 
 const UNEXISTING_FILTER: &str = "/99.999.9999.99999/";
 
+const BODY_BREWWEB: &str = "<html>
+<head>Head</head>
+<body>
+<a href=\"https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libcap-ng/0.9.3/1.el10/src/libcap-ng-0.9.3-1.el10.src.rpm\">download</a>
+</body>
+</html>";
+
 const BODY_NOT_DOWNLOADABLE: &str = "<html>
 <head>Head</head>
 <body>
@@ -96,6 +103,17 @@ fn links_downloadable_link_test_filter() {
         Ok(d) => assert_eq!(d, 0),
         Err(_e) => assert_eq!(0, 1),
     }
+}
+
+#[test]
+fn links_brewweb_link_test() {
+    verbose::is_verbose(false);
+    let link_lines = links::get_link_lines(String::from(BODY_BREWWEB));
+    assert_eq!(link_lines.len(), 1);
+    let extracted_links = links::get_links(link_lines);
+    assert_eq!(extracted_links.len(), 1);
+    assert!(extracted_links[0].contains("dc.redhat.com"));
+    assert!(extracted_links[0].contains(".rpm"));
 }
 
 #[test]


### PR DESCRIPTION
The tool failed to retrieve packages from brewweb because its download domain (dc.redhat.com) was not in the allowed domain list. Add it as a recognized domain so links from brewweb build pages are properly parsed.